### PR TITLE
Meganerd patch 1 specify bash

### DIFF
--- a/reindex.sh
+++ b/reindex.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-# This script requires bash, on some systems like Ubuntu, /bin/sh redirects to a different shell
-# such as dash, which will not properly run this script in it's current iteration.
+
 ########################################## Settings ##########################################
 # username - Admin user on the Jira Server
 username="jason.hensler"

--- a/reindex.sh
+++ b/reindex.sh
@@ -1,5 +1,6 @@
-#!/bin/sh
-
+#!/bin/bash
+# This script requires bash, on some systems like Ubuntu, /bin/sh redirects to a different shell
+# such as dash, which will not properly run this script in it's current iteration.
 ########################################## Settings ##########################################
 # username - Admin user on the Jira Server
 username="jason.hensler"


### PR DESCRIPTION
On systems like Debian and Ubuntu where /bin/sh redirects to a shell other than bash (on those systems it is typically /bin/dash), making the shebang specify /bin/bash explicitly will enable this script to run without call bash directly. 
